### PR TITLE
Pass -fsigned-char explicitly since code expects it to be signed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 
 CXX=c++
 INC=
-CXXFLAGS=-c -Wall -O2 -std=c++11 -pedantic -fPIC
+CXXFLAGS=-c -Wall -O2 -std=c++11 -pedantic -fPIC -fsigned-char
 LIBS=-lcrypto -lssl
 
 # If you have openssl or libressl with TLS1.3 support


### PR DESCRIPTION
Hello!

main.cc contains following condition:

```
while ((c = getopt(argc, argv, "l:p:R:u:F:P")) != -1) {
```

However, char is not always signed. In my case, while building with the following Dockerfile, the `getopt()` function returned 255 (which is the same as -1 but for unsigned char).
Not sure why the default is different on different systems, however in this PR I suggest explicitly pass this option to the compiler.

Reproduce Dockerfile:
```
FROM ubuntu:latest

# Update the system and install necessary packages
RUN apt-get update && \
    apt-get install -y dnsutils certbot openssl make g++ libssl-dev

COPY harddns /app
WORKDIR /app

RUN make && make install

COPY config /etc/harddns/harddns.conf

# Expose necessary ports
EXPOSE 443/tcp

CMD ["/usr/local/bin/harddnsd"]
```